### PR TITLE
Fix f-string related error

### DIFF
--- a/ai_inventory/ai_accounts_forecast/models/account_forecast.py
+++ b/ai_inventory/ai_accounts_forecast/models/account_forecast.py
@@ -34,7 +34,10 @@ def create_financial_forecast(
     # Validate forecast type
     valid_types = ["Cash Flow", "Revenue", "Expense", "Balance Sheet", "P&L"]
     if forecast_type not in valid_types:
-        raise ValueError(f"Forecast Type cannot be \"{forecast_type}\". It should be one of {', '.join(f'\"{t}\"' for t in valid_types)}")
+        raise ValueError(
+            f'Forecast Type cannot be "{forecast_type}". '
+            f"It should be one of {', '.join(map(repr, valid_types))}"
+        )
     
     try:
         # Get account details


### PR DESCRIPTION
This error is because you used escaped quotes (\") inside the f-string expression, which Python does not allow inside the inner {} part of an f-string.

The inner f-string f'\"{t}\"' is the issue.
You don’t need to escape quotes if you alternate ' and " correctly.

Explanation: "{t!r}" automatically wraps values in quotes using Python’s repr().

I have corrected the f-string on line 37 ai_inventory/ai_inventory/ai_accounts_forecast/models/account_forecast.py. You should now be able to install without the f-string related error.